### PR TITLE
Apple rejection guideline 2.5.1 (#1)

### DIFF
--- a/ios/RNReactNativeLocationSwitch.m
+++ b/ios/RNReactNativeLocationSwitch.m
@@ -20,12 +20,19 @@ RCT_REMAP_METHOD(enableLocationService,
     CLAuthorizationStatus status = [CLLocationManager authorizationStatus];
 
     if (![CLLocationManager locationServicesEnabled]) {
-        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"App-Prefs:root=Privacy&path=LOCATION"] options:@{}
+        /*
+        using "App-Prefs:root=Privacy&path=LOCATION" results in app store rejection under
+        Guideline 2.5.1 - Performance - Software Requirements
+        The use of non-public APIs is not permitted on the App Store
+        because it can lead to a poor user experience should these APIs change.
+        */
+        // show location settings
+        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString] options:@{}
                                  completionHandler:^(BOOL success) {}];
 
     } else if (status == kCLAuthorizationStatusDenied) {
         NSLog(@"Location Services Disabled");
-        
+
         // show location settings
         [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString] options:@{}
                                  completionHandler:^(BOOL success) {}];
@@ -42,7 +49,7 @@ RCT_REMAP_METHOD(isLocationEnabled,
                  onLocationDisable:(RCTResponseSenderBlock)errorCallback)
 {
     CLAuthorizationStatus status = [CLLocationManager authorizationStatus];
-    
+
     if (![CLLocationManager locationServicesEnabled] || status == kCLAuthorizationStatusDenied) {
         NSLog(@"Location Services Disabled");
         errorCallback(@[[NSNull null]]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-location-switch",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Philipp Weitz",
   "private": false,
   "license": "Apache-2.0",


### PR DESCRIPTION
Guideline 2.5.1 - Performance - Software Requirements Your app uses or references the following non-public APIs
Removed App-Prefs:root=Privacy&path=LOCATION and switched to UIApplicationOpenSettingsURLString so that the app doesn't get rejected during Apple Store Review.